### PR TITLE
fix(extension): edit styling for option panel

### DIFF
--- a/src/web/app/css/form.stylea.css
+++ b/src/web/app/css/form.stylea.css
@@ -1,14 +1,12 @@
 .styleA {
   @apply bg-transparent;
-
 }
 
 .styleA label,
 .styleA label.label,
 .styleA label.label-element {
     @apply
-    tracking-wide text-gray-700 text-sm
-
+    tracking-wide vsc-editor-fg vsc-font-size
     transition-colors
 }
 
@@ -26,7 +24,7 @@
 
 .styleA .control:focus-within label,
 .styleA .control:focus-within label.label {
-    @apply text-gray-600
+    @apply vsc-inputOpt-active-fg
 }
 
 /*
@@ -51,18 +49,19 @@
     w-full
     py-0.5 px-2
 
-    bg-gray-100
+    vsc-input-bg
     disabled:bg-gray-200
-    bg-opacity-50 focus:bg-opacity-100
+    bg-opacity-50
+    focus:vsc-inputOpt-active-fg focus:vsc-inputOpt-active-bg
 
     rounded-sm
 
     text-base
-    text-gray-700
+    vsc-input-fg
     leading-6
 
-    border border-gray-300
-    focus:border-gray-500
+    border vsc-input-border
+    focus:vsc-inputOpt-active-border
     transition-colors
 
     outline-none  appearance-none
@@ -144,21 +143,15 @@ fieldset.styleA.group .group-item {
     /*@apply*/
 }
 
-
-
-
-
-
-
 .styleA .control .description,
 .styleA .control .error {
-    @apply block h-2 text-sm
+    @apply block h-2 vsc-font-size-desc
 }
 .styleA .control .description {
-    @apply text-gray-500
+    @apply vsc-editor-fg
 }
 .styleA .control .error {
-    @apply text-red-500
+    @apply vsc-editor-error-fg
 }
 
 /**
@@ -249,17 +242,18 @@ fieldset.styleA.group .group-item {
 
 .styleA .tabs {
     @apply
-    flex
+    flex justify-between
 
     my-2
 
-    border-b border-gray-200
+    border-b vsc-tab-border
 }
 
 .styleA .tabs button {
     min-width: 100px;
     @apply
     py-1 px-2
+    vsc-tab-fg vsc-tab-bg vsc-tab-border
 
     focus:outline-none
 
@@ -276,8 +270,8 @@ fieldset.styleA.group .group-item {
 
 .styleA .tabs button.selected {
     @apply
-    text-gray-800
-    border-gray-800
+    vsc-tab-active-fg
+    vsc-tab-active-border
 }
 .styleA .tabs button:disabled {
     @apply

--- a/src/web/app/css/style.css
+++ b/src/web/app/css/style.css
@@ -3,120 +3,148 @@
 @tailwind utilities;
 
 @layer base {
-    body {
-        background-color: var(--vscode-editor-background);
-        font-size: 16px;
-    }
+  body {
+    background-color: var(--vscode-editor-background);
+    font-size: 16px;
+  }
 
-    :root {
-        --base-100: #e5e7eb;
-        --base-200: #9ca3af;
-        --base-300: #454545FF;
+  :root {
+    --base-100: #e5e7eb;
+    --base-200: #9ca3af;
+    --base-300: #454545ff;
 
-        --error: #911212;
+    --error: #911212;
 
-        --tool-control: #bfdbfe;
-        --tool-control-secondary: #dcfce7;
-        --tool-layout: #dbeafe;
-        --tool-accent: #fef3c7;
-        --tool-error: #fee2e2;
-        --toolItem-icon: #000;
-        --toolItem-border: rgba(60, 60, 60, 0.2);
-        --toolBar: var(--base-100);
-        --toolBar-bg: var(--base-100);
-        --toolBar-scrollbar: var(--base-300);
-        --toolBar-tab: var(--base-100);
-        --toolBar-tab-hover: var(--base-200);
-        --modal: #fff;
+    --tool-control: #bfdbfe;
+    --tool-control-secondary: #dcfce7;
+    --tool-layout: #dbeafe;
+    --tool-accent: #fef3c7;
+    --tool-error: #fee2e2;
+    --toolItem-icon: #000;
+    --toolItem-border: rgba(60, 60, 60, 0.2);
+    --toolBar: var(--base-100);
+    --toolBar-bg: var(--base-100);
+    --toolBar-scrollbar: var(--base-300);
+    --toolBar-tab: var(--base-100);
+    --toolBar-tab-hover: var(--base-200);
+    --modal: #fff;
 
-        --dropArea: rgb(250, 250, 250);
-        --dropArea-dots: var(--base-200);
-        --dropArea-dragBorder: var(--base-300);
+    --dropArea: rgb(250, 250, 250);
+    --dropArea-dots: var(--base-200);
+    --dropArea-dragBorder: var(--base-300);
 
-        --buttonRounded-hover: rgba(200, 200, 200, .5);
+    --buttonRounded-hover: rgba(200, 200, 200, 0.5);
 
-        --tool-categorization-tab-hover: rgb(255, 255, 255, 0.3);
-        --tool-reference-ref: var(--base-100);
-        --tool-control-input: #fff;
-        --tool-control-input-border: #eee;
-    }
+    --tool-categorization-tab-hover: rgb(255, 255, 255, 0.3);
+    --tool-reference-ref: var(--base-100);
+    --tool-control-input: #fff;
+    --tool-control-input-border: #eee;
+  }
 
-    .vscode {
-        --base-100: var(--vscode-editorHoverWidget-border);
-        --base-200: var(--vscode-editorWidget-border);
-        --base-300: var(--vscode-editorWidget-background);
+  .vscode {
+    --base-100: var(--vscode-editorHoverWidget-border);
+    --base-200: var(--vscode-editorWidget-border);
+    --base-300: var(--vscode-editorWidget-background);
 
-        --tool-control: var(--vscode-button-background);
-        --tool-control-secondary: var(--vscode-button-secondaryBackground);
-        --tool-layout: var(--vscode-input-background);
-        --tool-accent: var(--vscode-inputValidation-infoBackground);
-        --tool-error: var(--vscode-inputOption-errorBackground);
-        --toolItem-icon: var(--vscode-editor-foreground);
-        --toolItem-border:rgb(100,100,100,0.6);
-        --toolBar: var(--base-100);
-        --toolBar-bg: var(--base-300);
-        --toolBar-scrollbar: var(--base-300);
-        --toolBar-tab: var(--base-100);
-        --toolBar-tab-hover: var(--base-200);
-        --modal:var(--base-100);
+    --tool-control: var(--vscode-button-background);
+    --tool-control-secondary: var(--vscode-button-secondaryBackground);
+    --tool-layout: var(--vscode-input-background);
+    --tool-accent: var(--vscode-inputValidation-infoBackground);
+    --tool-error: var(--vscode-inputOption-errorBackground);
+    --toolItem-icon: var(--vscode-editor-foreground);
+    --toolItem-border: rgb(100, 100, 100, 0.6);
+    --toolBar: var(--base-100);
+    --toolBar-bg: var(--base-300);
+    --toolBar-scrollbar: var(--base-300);
+    --toolBar-tab: var(--base-100);
+    --toolBar-tab-hover: var(--base-200);
+    --modal: var(--base-100);
 
-        --dropArea: var(--base-200);
-        --dropArea-dots: var(--base-100);
-        --dropArea-dragBorder: var(--base-100);
+    --dropArea: var(--base-200);
+    --dropArea-dots: var(--base-100);
+    --dropArea-dragBorder: var(--base-100);
 
-        --buttonRounded-hover: var(--vscode-button-hoverBackground);
+    --buttonRounded-hover: var(--vscode-button-hoverBackground);
 
-        --tool-categorization-tab-hover:rgb(255,255,255,0.2);
-        --tool-control-input: rgb(255,255,255,0.3);
-        --tool-control-input-border: rgb(0,0,0,0.5);
-    }
+    --tool-categorization-tab-hover: rgb(255, 255, 255, 0.2);
+    --tool-control-input: rgb(255, 255, 255, 0.3);
+    --tool-control-input-border: rgb(0, 0, 0, 0.5);
+  }
 
-    .vscode .card {
-        background-color: var(--base-300);
-    }
+  .vscode .card {
+    background-color: var(--base-300);
+  }
 
-    .vscode .card textarea {
-        background-color: var(--vscode-editor-background);
-        font-size: var(--vscode-font-size);
-    }
+  .vscode .card textarea {
+    background-color: var(--vscode-editor-background);
+    font-size: var(--vscode-font-size);
+  }
 
-    .vscode .card .styleA label {
-        color: var(--vscode-editor-foreground);
-        font-size: var(--vscode-font-size);
-    }
-    .vscode .card .styleA .control:focus-within label,
-    .vscode .card .styleA .control .description {
-        color: var(--vscode-inputOption-activeForeground);
-    }
+  h1 {
+    @apply text-xl sm:text-2xl;
+  }
 
-    .vscode .card .styleA input,
-    .vscode .card .styleA select {
-        background-color: var(--vscode-input-background);
-        color: var(--vscode-input-foreground);
-        border-color: var(--vscode-input-border);
-    }
-    .vscode .card .styleA .error {
-        color: var(--vscode-editorError-foreground);
-        font-size: calc(var(--vscode-font-size) - 2px);
-    }
-    .vscode .card .styleA input:focus,
-    .vscode .card .styleA select:focus {
-        background-color: var(--vscode-inputOption-activeBackground);
-        color: var(--vscode-inputOption-activeForeground);
-        border-color: var(--vscode-inputOption-activeBorder);
-    }
-
-    h1 {
-        @apply
-        text-xl sm:text-2xl
-    }
-
-    h2 {
-        @apply
-        text-lg sm:text-xl
-    }
+  h2 {
+    @apply text-lg sm:text-xl;
+  }
 }
 
 @layer components {
+  .vsc-font-size {
+    font-size: var(--vscode-font-size);
+  }
+  .vsc-font-size-desc {
+    font-size: calc(var(--vscode-font-size) - 2px);
+  }
+  .vsc-disabled-fg {
+    color: var(--vscode-disabledForeground);
+  }
 
+  /* Editor */
+  .vsc-editor-fg {
+    color: var(--vscode-editor-foreground);
+  }
+  .vsc-editor-error-fg {
+    color: var(--vscode-editorError-foreground);
+  }
+
+  /* Input */
+  .vsc-input-fg {
+    color: var(--vscode-input-foreground);
+  }
+  .vsc-input-bg {
+    background-color: var(--vscode-input-background);
+  }
+  .vsc-input-border {
+    border-color: var(--vscode-input-border);
+  }
+  .vsc-inputOpt-active-fg {
+    color: var(--vscode-inputOption-activeForeground);
+  }
+  .vsc-inputOpt-active-bg {
+    background-color: var(--vscode-inputOption-activeBackground);
+  }
+  .vsc-inputOpt-active-border {
+    border-color: var(--vscode-inputOption-activeBorder);
+  }
+
+  /* Editor Groups & Tabs */
+  .vsc-tab-fg {
+    color: var(--vscode-tab-inactiveForeground);
+  }
+  .vsc-tab-bg {
+    background-color: var(--vscode-tab-inactiveBackground);
+  }
+  .vsc-tab-border {
+    border-color: var(--vscode-tab-border);
+  }
+  .vsc-tab-active-fg {
+    color: var(--vscode-tab-activeForeground);
+  }
+  .vsc-tab-active-bg {
+    background-color: var(--vscode-tab-activeBackground);
+  }
+  .vsc-tab-active-border {
+    border-color: var(--vscode-inputOption-activeBorder);
+  }
 }


### PR DESCRIPTION
## Description 
There is no styling for the options panel. It uses the `styleA class` like the preview, so we want to add the vscode colors to that class.

## Checklist 
- [x] No obvious errors or bugs (`npm run start` works)
- [x] Using a semantic commit messages as described in [here](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
